### PR TITLE
Add Pylint command to jinja template

### DIFF
--- a/project_template/Makefile.jinja
+++ b/project_template/Makefile.jinja
@@ -24,6 +24,7 @@ format:  ## Format the code.
 lint:  ## Run all linters (black/ruff/pylint/mypy).
 	{{ package_manager }} run black --check .
 	{{ package_manager }} run ruff check .
+	{{ package_manager }} run pylint {{ module_name }}
 	make mypy
 
 .PHONY: test


### PR DESCRIPTION
### What is the context of this PR?

Pylint is mentioned in the [README.md](https://github.com/ONSdigital/ons-python-template?tab=readme-ov-file#features) but not implemented in the [MAKEFILE](https://github.com/ONSdigital/ons-python-template/blob/main/project_template/Makefile.jinja#L23) of the template and when the template is used, evident in the [demo](https://github.com/ONSdigital/ons-python-template-demo/blob/main/Makefile#L24).

### How to review

Pull changes, use template, run `make lint` to run black, ruff, mypy and **pylint**.
