### PR TITLE
Add CODEOWNERS File to Template Repo and The Project Template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ONSdigital

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
 * @ONSdigital

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @ONSdigital
+* @ONSdigital/ons-python-template

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 * @ONSdigital/ons-python-template

--- a/copier.yml
+++ b/copier.yml
@@ -57,7 +57,10 @@ repository_owner:
 code_owner:
   type: str
   help: "What is your CODEOWNERS default? (e.g. @org/team or @username)"
-  default: "@{{ repository_owner }}"
+  validator: >-
+    {% if not code_owner.startswith('@') %}
+    CODEOWNERS must start with '@' (e.g. @username or @org/team)
+    {% endif %}
 
 repository_visibility:
   type: str

--- a/copier.yml
+++ b/copier.yml
@@ -54,6 +54,11 @@ repository_owner:
   help: "What is your repository owner? (e.g. your GitHub username)"
   default: "ONSdigital"
 
+code_owner:
+  type: str
+  help: "What is your CODEOWNERS default? (e.g. @org/team or @username)"
+  default: "@{{ repository_owner }}"
+
 repository_visibility:
   type: str
   help: "What is your repository visibility?"

--- a/project_template/.github/CODEOWNERS
+++ b/project_template/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* {{ code_owner }}

--- a/project_template/.github/CODEOWNERS
+++ b/project_template/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* {{ code_owner }}

--- a/project_template/.github/CODEOWNERS.jinja
+++ b/project_template/.github/CODEOWNERS.jinja
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* {{ code_owner }}

--- a/project_template/.github/CODEOWNERS.jinja
+++ b/project_template/.github/CODEOWNERS.jinja
@@ -1,3 +1,3 @@
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 * {{ code_owner }}


### PR DESCRIPTION
### What is the context of this PR?

- Added a `CODEOWNERS` file to the template repo itself.
- Added a functionality where an automatically `CODEOWNERS` file is created for a generated template repo.
  - Additionally, the developers are able to specify their code owner, and it will be reflected in the generated `CODEOWNERS` file.

### How to review

- Test the changes locally:
  - By default, the generated template repo should contain a `CODEOWNERS` file.
  - When entering your own code owner config, it should be reflected in the generated template repo.

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
