### PR TITLE
fix: markdownlint in README + dynamically generate LICENCE year

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,14 +572,21 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## License
 
-See [LICENSE](LICENSE) for details.
+Copyright © 2024 [Crown Copyright][crown-copyright] (Office for National Statistics)
+
+Unless stated otherwise, the codebase is released under the [MIT License](LICENSE).
+This covers both the codebase and any sample code in the documentation.
+
+The documentation in this repo are released under the [Open Government Licence v3.0][ogl-v3].
 
 ---
 
 [//]: # (:TODO: Enable link checking once https://github.com/tcort/markdown-link-check/issues/250 is resolved.)
-<!-- markdown-link-check-disable -->
 
 [alternative-software-tools]: #alternatives-softwaretools
 
 [updating-project]: #updating-project-with-template-changes
-<!-- markdown-link-check-enable -->
+
+[crown-copyright]: https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/
+
+[ogl-v3]: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/

--- a/project_template/README.md.jinja
+++ b/project_template/README.md.jinja
@@ -187,7 +187,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## License
 
-Copyright © 2026 [Crown Copyright][crown-copyright] (Office for National Statistics)
+Copyright © {{ '%Y' | strftime }} [Crown Copyright][crown-copyright] (Office for National Statistics)
 
 Unless stated otherwise, the codebase is released under the [MIT License](LICENSE).
 This covers both the codebase and any sample code in the documentation.

--- a/project_template/README.md.jinja
+++ b/project_template/README.md.jinja
@@ -187,9 +187,13 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## License
 
-Copyright © 2024 [Crown Copyright](https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/) (Office for National Statistics)
+Copyright © 2026 [Crown Copyright][crown-copyright] (Office for National Statistics)
 
-Unless stated otherwise, the codebase is released under the [MIT License](LICENSE). This covers both the codebase and any sample code in the documentation.
+Unless stated otherwise, the codebase is released under the [MIT License](LICENSE).
+This covers both the codebase and any sample code in the documentation.
 
-The documentation in this repo are released under the [Open Government Licence v3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).
+The documentation in this repo are released under the [Open Government Licence v3.0][ogl-v3].
+
+[crown-copyright]: https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/
+[ogl-v3]: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
 {%- endif %}

--- a/project_template/{% if is_public_repo %}LICENSE{% endif %}
+++ b/project_template/{% if is_public_repo %}LICENSE{% endif %}
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (c) 2024, Crown Copyright (Office for National Statistics)
+Copyright (c) 2026, Crown Copyright (Office for National Statistics)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the "Software"), to deal in the Software without restriction, including without limitation the

--- a/project_template/{% if is_public_repo %}LICENSE{% endif %}.jinja
+++ b/project_template/{% if is_public_repo %}LICENSE{% endif %}.jinja
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (c) 2026, Crown Copyright (Office for National Statistics)
+Copyright (c) {{ '%Y' | strftime }}, Crown Copyright (Office for National Statistics)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the "Software"), to deal in the Software without restriction, including without limitation the


### PR DESCRIPTION
### What is the context of this PR?

- Fixes markdown lint issues in the README.md
- Adds licence details to base repo.
- Dynamically calculate current year for LICENCE for generated projects

### How to review

Ensure changes make sense

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
