### PR TITLE
chore(kics): remove redundant SHA pinning exclusion

### DIFF
--- a/.github/linters/kics.config
+++ b/.github/linters/kics.config
@@ -1,5 +1,0 @@
-# vim: set filetype=yaml:
-
-# https://docs.kics.io/latest/
-exclude-queries:
-  - "555ab8f9-2001-455e-a077-f2d0f41e2fb9"  # Allow not pinning to commit SHA in GitHub CI

--- a/project_template/.github/linters/kics.config
+++ b/project_template/.github/linters/kics.config
@@ -1,5 +1,0 @@
-# vim: set filetype=yaml:
-
-# https://docs.kics.io/latest/
-exclude-queries:
-  - "555ab8f9-2001-455e-a077-f2d0f41e2fb9"  # Allow not pinning to commit SHA in GitHub CI


### PR DESCRIPTION
### What is the context of this PR?

Remove the KICS exclusion for unpinned GitHub Actions.

Commit SHA pinning is already enforced by [zizmor](https://github.com/zizmorcore/zizmor), so this disable is misleading, as it is still checked (just by another linter atm), so this override is unnecessary and can coexist with zizmor, which also checks the same rule.

### How to review

Ensure changes make sense.

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
